### PR TITLE
Ensure final status logged before shutdown

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -373,6 +373,14 @@ class MainWindow(QWidget):
             was_online = online
 
     def cleanup(self):
+        global afk_state, afk_period_start, notafk_period_start
+
+        now = datetime.now()
+        if afk_state:
+            log_status_period(afk_period_start, now, "afk")
+        else:
+            log_status_period(notafk_period_start, now, "not-afk")
+
         self.active = False
         report_status("offline")
         kill_all_forticlient_processes()


### PR DESCRIPTION
## Summary
- log last afk/not-afk period in `MainWindow.cleanup`
- capture current time and post interval before stopping tracking

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883df12efc0832b803f8a77bf3bc001