### PR TITLE
Fix daily total on index

### DIFF
--- a/server.py
+++ b/server.py
@@ -271,7 +271,6 @@ def get_current_status():
             .filter(
                 StatusLog.username == log.username,
                 StatusLog.hostname == log.hostname,
-                StatusLog.status == "not-afk",
                 func.substr(StatusLog.start_time, 1, 10) == today_str,
             )
             .scalar()


### PR DESCRIPTION
## Summary
- show total online time (active + afk) on the index page instead of only active time

## Testing
- `python -m py_compile server.py models.py agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6883f1f703fc832ba4513e29f03052f8