### PR TITLE
Remove 'Today Online Users' section

### DIFF
--- a/server.py
+++ b/server.py
@@ -512,8 +512,6 @@ def reports():
             {table}
         </tbody>
       </table>
-      <h3>Bugün Online Kullanıcılar</h3>
-      {generate_today_online_table()}
       <a class="btn btn-secondary" href="/">Geri Dön</a>
       <a class="btn btn-primary" href="/weekly_report" style="margin-left:10px">Haftalık Detay</a>
     </div>


### PR DESCRIPTION
## Summary
- simplify the reports page by dropping the 'Bugün Online Kullanıcılar' header and table

## Testing
- `python -m py_compile server.py models.py agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68846c0730f4832bb3aed4918d7e38b6