### PR TITLE
Update navigation buttons

### DIFF
--- a/templates/daily_timeline.html
+++ b/templates/daily_timeline.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <div class="container">
+  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
   <h2>📈 Günlük Zaman Çizelgesi</h2>
   <form method="get" class="row mb-3">
     <div class="col">
@@ -30,7 +31,7 @@
     </div>
   </form>
   <div id="timeline"></div>
-  <a class="btn btn-secondary mt-3" href="/usage_report">Geri Dön</a>
+  <a class="btn btn-secondary mt-3" href="/">Geri Dön</a>
 </div>
 <script src="https://unpkg.com/vis-timeline@latest/standalone/umd/vis-timeline-graph2d.min.js"></script>
 <script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,8 +40,9 @@
     </tbody>
   </table>
   <a class="btn btn-secondary" href="/api/statuslogs">API: Status Logs</a>
-  <a class="btn btn-primary" href="/reports" style="margin-left:10px">Kullanıcı Raporları</a>
+  <a class="btn btn-primary" href="/weekly_report" style="margin-left:10px">Haftalık Detay</a>
   <a class="btn btn-primary" href="/usage_report" style="margin-left:10px">Kullanım Raporları</a>
+  <a class="btn btn-info" href="/daily_timeline" style="margin-left:10px">Zaman Çizelgesi</a>
 </div>
 </body>
 </html>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -12,6 +12,7 @@
 </head>
 <body>
 <div class="container">
+  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
   <h2>📝 Bugünkü Kullanıcı Detayları</h2>
   <table class="table table-bordered table-striped shadow">
     <thead class="table-dark">
@@ -34,7 +35,6 @@
     </tbody>
   </table>
   <a class="btn btn-secondary" href="/">Geri Dön</a>
-  <a class="btn btn-primary" href="/weekly_report" style="margin-left:10px">Haftalık Detay</a>
 </div>
 </body>
 </html>

--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -12,6 +12,7 @@
 </head>
 <body>
 <div class="container">
+  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
   <h2>📊 Kullanım Detayları</h2>
   <a class="btn btn-info mb-3" href="{{ timeline_url }}">Zaman Çizelgesi</a>
   <form method="get" class="row mb-3">
@@ -54,7 +55,7 @@
       {% endfor %}
     </tbody>
   </table>
-  <a class="btn btn-secondary" href="/reports">Geri Dön</a>
+  <a class="btn btn-secondary" href="/">Geri Dön</a>
 </div>
 </body>
 </html>

--- a/templates/weekly_report.html
+++ b/templates/weekly_report.html
@@ -12,6 +12,7 @@
 </head>
 <body>
 <div class="container">
+  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
   <h2>🗓️ Haftalık Kullanıcı Raporu</h2>
   <form method="get" class="row mb-3">
     <div class="col">
@@ -48,7 +49,7 @@
       {% endfor %}
     </tbody>
   </table>
-  <a class="btn btn-secondary" href="/reports">Geri Dön</a>
+  <a class="btn btn-secondary" href="/">Geri Dön</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- flatten navigation links
- add back buttons at the top of report pages
- add direct links to weekly report and timeline from the home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6885085e95d0832bb3f1c8258578e184