### PR TITLE
Move back buttons next to headings

### DIFF
--- a/templates/daily_timeline.html
+++ b/templates/daily_timeline.html
@@ -13,8 +13,10 @@
 </head>
 <body>
 <div class="container">
-  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
-  <h2>📈 Günlük Zaman Çizelgesi</h2>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">📈 Günlük Zaman Çizelgesi</h2>
+    <a class="btn btn-secondary" href="/">Geri Dön</a>
+  </div>
   <form method="get" class="row mb-3">
     <div class="col">
       <select name="username" class="form-select">
@@ -31,7 +33,6 @@
     </div>
   </form>
   <div id="timeline"></div>
-  <a class="btn btn-secondary mt-3" href="/">Geri Dön</a>
 </div>
 <script src="https://unpkg.com/vis-timeline@latest/standalone/umd/vis-timeline-graph2d.min.js"></script>
 <script>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -12,8 +12,10 @@
 </head>
 <body>
 <div class="container">
-  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
-  <h2>📝 Bugünkü Kullanıcı Detayları</h2>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">📝 Bugünkü Kullanıcı Detayları</h2>
+    <a class="btn btn-secondary" href="/">Geri Dön</a>
+  </div>
   <table class="table table-bordered table-striped shadow">
     <thead class="table-dark">
         <tr>
@@ -34,7 +36,6 @@
         {% endfor %}
     </tbody>
   </table>
-  <a class="btn btn-secondary" href="/">Geri Dön</a>
 </div>
 </body>
 </html>

--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -12,8 +12,10 @@
 </head>
 <body>
 <div class="container">
-  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
-  <h2>📊 Kullanım Detayları</h2>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">📊 Kullanım Detayları</h2>
+    <a class="btn btn-secondary" href="/">Geri Dön</a>
+  </div>
   <a class="btn btn-info mb-3" href="{{ timeline_url }}">Zaman Çizelgesi</a>
   <form method="get" class="row mb-3">
     <div class="col">
@@ -55,7 +57,6 @@
       {% endfor %}
     </tbody>
   </table>
-  <a class="btn btn-secondary" href="/">Geri Dön</a>
 </div>
 </body>
 </html>

--- a/templates/weekly_report.html
+++ b/templates/weekly_report.html
@@ -12,8 +12,10 @@
 </head>
 <body>
 <div class="container">
-  <a class="btn btn-secondary mb-3" href="/">Geri Dön</a>
-  <h2>🗓️ Haftalık Kullanıcı Raporu</h2>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">🗓️ Haftalık Kullanıcı Raporu</h2>
+    <a class="btn btn-secondary" href="/">Geri Dön</a>
+  </div>
   <form method="get" class="row mb-3">
     <div class="col">
       <select name="username" class="form-select">
@@ -49,7 +51,6 @@
       {% endfor %}
     </tbody>
   </table>
-  <a class="btn btn-secondary" href="/">Geri Dön</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- align all `Geri Dön` buttons with the page heading
- remove duplicate bottom buttons

## Testing
- `python -m py_compile server.py agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68850a9571a8832b959e5fc8b55f3649