### PR TITLE
Fix back button layout and remove timeline from usage report

### DIFF
--- a/server.py
+++ b/server.py
@@ -801,8 +801,6 @@ def usage_report():
 
     usage_rows = get_window_usage_data(selected_user, start.isoformat(), end.isoformat())
 
-    timeline_url = f"/daily_timeline?username={selected_user}&date={base_date.isoformat()}"
-
     return render_template(
         "usage_report.html",
         usernames=usernames,
@@ -810,7 +808,6 @@ def usage_report():
         range_param=range_param,
         base_date=base_date,
         usage_rows=usage_rows,
-        timeline_url=timeline_url,
         format_duration=format_duration,
     )
 

--- a/templates/daily_timeline.html
+++ b/templates/daily_timeline.html
@@ -13,9 +13,9 @@
 </head>
 <body>
 <div class="container">
-  <div class="d-flex justify-content-between align-items-center mb-3">
+  <div class="d-flex align-items-center mb-3">
+    <a class="btn btn-secondary me-3" href="/">Geri Dön</a>
     <h2 class="mb-0">📈 Günlük Zaman Çizelgesi</h2>
-    <a class="btn btn-secondary" href="/">Geri Dön</a>
   </div>
   <form method="get" class="row mb-3">
     <div class="col">

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -12,9 +12,9 @@
 </head>
 <body>
 <div class="container">
-  <div class="d-flex justify-content-between align-items-center mb-3">
+  <div class="d-flex align-items-center mb-3">
+    <a class="btn btn-secondary me-3" href="/">Geri Dön</a>
     <h2 class="mb-0">📝 Bugünkü Kullanıcı Detayları</h2>
-    <a class="btn btn-secondary" href="/">Geri Dön</a>
   </div>
   <table class="table table-bordered table-striped shadow">
     <thead class="table-dark">

--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -12,11 +12,10 @@
 </head>
 <body>
 <div class="container">
-  <div class="d-flex justify-content-between align-items-center mb-3">
+  <div class="d-flex align-items-center mb-3">
+    <a class="btn btn-secondary me-3" href="/">Geri Dön</a>
     <h2 class="mb-0">📊 Kullanım Detayları</h2>
-    <a class="btn btn-secondary" href="/">Geri Dön</a>
   </div>
-  <a class="btn btn-info mb-3" href="{{ timeline_url }}">Zaman Çizelgesi</a>
   <form method="get" class="row mb-3">
     <div class="col">
       <select name="username" class="form-select">

--- a/templates/weekly_report.html
+++ b/templates/weekly_report.html
@@ -12,9 +12,9 @@
 </head>
 <body>
 <div class="container">
-  <div class="d-flex justify-content-between align-items-center mb-3">
+  <div class="d-flex align-items-center mb-3">
+    <a class="btn btn-secondary me-3" href="/">Geri Dön</a>
     <h2 class="mb-0">🗓️ Haftalık Kullanıcı Raporu</h2>
-    <a class="btn btn-secondary" href="/">Geri Dön</a>
   </div>
   <form method="get" class="row mb-3">
     <div class="col">


### PR DESCRIPTION
## Summary
- move 'Geri Dön' buttons to the left of page titles
- drop the timeline link from usage details

## Testing
- `python -m py_compile server.py`
- `python -m py_compile models.py`


------
https://chatgpt.com/codex/tasks/task_e_68850c3567ac832baf11d0399146f69a