### PR TITLE
Fix initial zoom on daily timeline

### DIFF
--- a/templates/daily_timeline.html
+++ b/templates/daily_timeline.html
@@ -77,8 +77,10 @@
     applyZoom(this.value);
   });
 
-  // Apply the selected zoom on initial load
-  applyZoom(zoomSelect.value);
+  // Apply the selected zoom after timeline is rendered
+  setTimeout(function () {
+    applyZoom(zoomSelect.value);
+  }, 100);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure zoom settings apply after timeline renders

## Testing
- `pytest -q`
- `python -m py_compile server.py models.py agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6885117e4664832ba56bfb0f55d07fb6