### PR TITLE
Add total daily time on main page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,8 @@
             <th>Aktif Pencere</th>
             <th>AFK Durumu</th>
             <th>IP</th>
-            <th>Bugünkü Süre</th>
+            <th>Bugün Aktif</th>
+            <th>Bugün Toplam</th>
         </tr>
     </thead>
     <tbody>
@@ -35,6 +36,7 @@
             <td>{{ row.shown_status }}</td>
             <td>{{ row.ip }}</td>
             <td>{{ format_duration(row.today_active) }}</td>
+            <td>{{ format_duration(row.today_total) }}</td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- calculate today's AFK time and total time for each user/host
- show both "Bugün Aktif" and "Bugün Toplam" columns on the main page
- update HTML table generator to include the new data

## Testing
- `python -m py_compile server.py`
- `python -m py_compile agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68854beba8b4832b8a4be85c48cf9be0