### PR TITLE
Show daily active and AFK times

### DIFF
--- a/server.py
+++ b/server.py
@@ -694,6 +694,19 @@ def reports():
     )
 
 
+@app.route("/api/today_totals")
+def api_today_totals():
+    """Return today's totals for active and AFK times."""
+    username = request.args.get("username")
+    details = get_today_user_details()
+    if username:
+        for item in details:
+            if item["username"] == username:
+                return jsonify(item)
+        return jsonify({"error": "not_found"}), 404
+    return jsonify(details)
+
+
 def get_weekly_report(username: str, week_start: date):
     """Return daily online/active/afk totals for given user and week."""
     results = []


### PR DESCRIPTION
## Summary
- add `/api/today_totals` API to report today's active/AFK totals
- track today's active and AFK counters in the agent
- display today's active/AFK time in the agent UI and keep it updated

## Testing
- `python -m py_compile agent/agent.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_68854d8148c0832b8150a4113ee7d5a6