### PR TITLE
Add 'remember me' option to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Sunucu varsayılan olarak 5050 portunda çalışır.
 - `OFFLINE_MULTIPLIER` – Kullanıcıyı çevrimdışı kabul etmeden önce beklenen keepalive süresinin kaç katı süre geçmesi gerektiği.
 - `MONITOR_INTERVAL` – Arka plan izleme iş parçacığının kontrol aralığı (saniye).
 - `TIMEZONE_OFFSET` – Raporlarda kullanılacak saat dilimi ofseti (UTC + değer).
+- `REMEMBER_ME_DAYS` – "Beni Hatırla" seçiliyse oturumun geçerli kalacağı gün
+  sayısı (varsayılan 30).
 
 ## API Uç Noktaları
 - `POST /api/log` – `log_type` alanı "window" veya "status" olduğunda ilgili verileri kaydeder.

--- a/server.py
+++ b/server.py
@@ -36,6 +36,8 @@ TIMEZONE_OFFSET = int(os.environ.get("TIMEZONE_OFFSET", 3))  # hours
 LDAP_URI = os.environ.get("LDAP_URI")
 LDAP_BASE_DN = os.environ.get("LDAP_BASE_DN")
 LDAP_DOMAIN = os.environ.get("LDAP_DOMAIN")
+REMEMBER_ME_DAYS = int(os.environ.get("REMEMBER_ME_DAYS", 30))
+app.permanent_session_lifetime = timedelta(days=REMEMBER_ME_DAYS)
 ADMIN_SET = {
     u.strip().lower()
     for u in os.environ.get("ADMIN_USERS", "").split(",")
@@ -689,9 +691,11 @@ def login():
     if request.method == "POST":
         username = request.form.get("username")
         password = request.form.get("password")
+        remember = request.form.get("remember")
         if username and password and ldap_auth(username, password):
             session["user"] = username
             session["is_admin"] = is_admin(username)
+            session.permanent = bool(remember)
             next_url = request.args.get("next") or url_for("index")
             return redirect(next_url)
         flash("Giriş başarısız")

--- a/templates/login.html
+++ b/templates/login.html
@@ -25,6 +25,10 @@
       <label class="form-label">Şifre</label>
       <input type="password" name="password" class="form-control" required>
     </div>
+    <div class="mb-3 form-check">
+      <input type="checkbox" class="form-check-input" id="remember" name="remember">
+      <label class="form-check-label" for="remember">Beni Hatırla</label>
+    </div>
     <button type="submit" class="btn btn-primary">Giriş Yap</button>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- add optional persistent session for login
- expose `REMEMBER_ME_DAYS` configuration in README
- show "Beni Hatırla" checkbox in login page

## Testing
- `python -m py_compile agent/agent.py models.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_6886647d06d0832bb8db788adfd89045