### PR TITLE
Add API logging screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Sunucu varsayılan olarak 5050 portunda çalışır.
 - `POST /report` – Kullanıcının çevrim içi/çevrim dışı/afk durumunu bildirir.
 - `GET /api/statuslogs` – Son 50 durum kaydını JSON olarak döndürür.
 - `GET /api/window_usage` – Belirtilen kullanıcı için pencere kullanım süresi özetini döndürür.
+- `GET /api_logs` – Tüm API isteklerinin ham loglarını görüntüler (sadece admin).
 
 Ayrıca `/`, `/daily_timeline`, `/weekly_report` ve `/usage_report` gibi HTML sayfaları mevcuttur.
 

--- a/models.py
+++ b/models.py
@@ -34,3 +34,14 @@ class ReportLog(db.Model):
     ip = db.Column(db.String(64))
     status = db.Column(db.String(32))  # online/offline/keepalive/afk/not-afk
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class ApiLog(db.Model):
+    """Raw JSON payloads received from API clients."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    endpoint = db.Column(db.String(64))
+    hostname = db.Column(db.String(128))
+    username = db.Column(db.String(128))
+    payload = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/templates/api_logs.html
+++ b/templates/api_logs.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>API Logları</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body { background: #f6f6fa; }
+        .container { max-width: 900px; margin-top: 40px; }
+        table { font-size: 15px; }
+        h2 { margin-bottom: 20px; }
+        pre { white-space: pre-wrap; word-break: break-all; margin: 0; }
+    </style>
+</head>
+<body>
+<div class="container">
+  <div class="d-flex align-items-center mb-3">
+    <a class="btn btn-secondary me-3" href="/">Geri Dön</a>
+    <h2 class="mb-0">API Logları</h2>
+  </div>
+  <table class="table table-bordered table-striped shadow">
+    <thead class="table-dark">
+      <tr>
+        <th>Zaman</th>
+        <th>Endpoint</th>
+        <th>Kullanıcı</th>
+        <th>Hostname</th>
+        <th>Payload</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for log in logs %}
+      <tr>
+        <td>{{ log.created_at }}</td>
+        <td>{{ log.endpoint }}</td>
+        <td>{{ log.username }}</td>
+        <td>{{ log.hostname }}</td>
+        <td><pre>{{ log.payload }}</pre></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,6 +45,9 @@
     </tbody>
   </table>
   <a class="btn btn-secondary" href="/api/statuslogs">API: Status Logs</a>
+  {% if session.get('is_admin') %}
+  <a class="btn btn-warning" href="/api_logs" style="margin-left:10px">API Logs</a>
+  {% endif %}
   <a class="btn btn-primary" href="/weekly_report" style="margin-left:10px">Haftalık Detay</a>
   <a class="btn btn-primary" href="/usage_report" style="margin-left:10px">Kullanım Raporları</a>
   <a class="btn btn-info" href="/daily_timeline" style="margin-left:10px">Zaman Çizelgesi</a>


### PR DESCRIPTION
## Summary
- log raw requests from `/api/log` and `/report` into new `ApiLog` table
- create `/api_logs` page to show last 100 API entries
- expose link to API Logs for admin users

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688666c0b308832b8451b1cc32bd1206