### PR TITLE
Add basic error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 data/
 .env
+logs/
+server.log

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Bu depo, evden çalışan kullanıcıların pencere ve AFK durumlarını takip e
 
 Sunucu varsayılan olarak 5050 portunda çalışır.
 
+Başlatıldığında sunucu, `LOG_DIR` altında `server.log` dosyasına hata
+ve uyarı mesajlarını yazar.
+
 ## Ortam Değişkenleri
 - `SECRET` – İstemcilerin gönderdiği istekleri doğrulamak için kullanılan anahtar.
 - `KEEPALIVE_INTERVAL` – Keepalive bildirimlerinin beklenen aralığı (saniye).
@@ -34,6 +37,7 @@ Sunucu varsayılan olarak 5050 portunda çalışır.
 - `TIMEZONE_OFFSET` – Raporlarda kullanılacak saat dilimi ofseti (UTC + değer).
 - `REMEMBER_ME_DAYS` – "Beni Hatırla" seçiliyse oturumun geçerli kalacağı gün
   sayısı (varsayılan 30).
+- `LOG_DIR` – Sunucu günlüklerinin yazılacağı klasör (varsayılan `logs`).
 
 ## API Uç Noktaları
 - `POST /api/log` – `log_type` alanı "window" veya "status" olduğunda ilgili verileri kaydeder.


### PR DESCRIPTION
## Summary
- log requests that fail secret validation
- warn invalid secret attempts in `/api/log` and `/report`
- configure logging to write server logs to `LOG_DIR/server.log`
- document logging directory and ignore log files

## Testing
- `python -m py_compile server.py agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68866889ef94832b9e7ac974cd64c482