### PR TITLE
Add DEBUG utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ve uyarı mesajlarını yazar.
 - `REMEMBER_ME_DAYS` – "Beni Hatırla" seçiliyse oturumun geçerli kalacağı gün
   sayısı (varsayılan 30).
 - `LOG_DIR` – Sunucu günlüklerinin yazılacağı klasör (varsayılan `logs`).
+- `DEBUG` – `1` veya `true` ise ek hata ayıklama mesajları loglanır.
 
 ## API Uç Noktaları
 - `POST /api/log` – `log_type` alanı "window" veya "status" olduğunda ilgili verileri kaydeder.

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -14,6 +14,8 @@ import json
 from datetime import datetime, timedelta
 from pynput import mouse, keyboard
 
+from debug_utils import DEBUG
+
 from PyQt5.QtWidgets import QApplication, QWidget, QPushButton, QVBoxLayout, QTextEdit, QLabel
 from PyQt5.QtGui import QIcon, QTextCursor
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QTimer
@@ -128,6 +130,7 @@ def send_log_to_server(log_type, data):
         data['hostname'] = get_hostname()
         data['username'] = get_username()
         data['secret'] = SECRET
+        DEBUG(f"send_log_to_server {log_type} {data.get('window_title') or data.get('status')}")
         response = requests.post(f"{SERVER_URL}/api/log", json=data, timeout=2)
         return response.status_code == 200
     except Exception as e:
@@ -278,6 +281,7 @@ def server_accessible(attempts=2, delay=2):
         try:
             r = requests.get(SERVER_URL, timeout=5)
             if r.status_code in (200, 404):
+                DEBUG("server_accessible ok")
                 return True
         except Exception:
             pass

--- a/debug_utils.py
+++ b/debug_utils.py
@@ -1,0 +1,9 @@
+import os
+import logging
+
+DEBUG_MODE = os.environ.get("DEBUG", "").lower() in ("1", "true", "yes")
+
+def DEBUG(message: str) -> None:
+    """Log debug message when DEBUG_MODE is enabled."""
+    if DEBUG_MODE:
+        logging.info(f"[DEBUG] {message}")

--- a/server.py
+++ b/server.py
@@ -20,6 +20,7 @@ import threading
 import time
 import json
 import logging
+from debug_utils import DEBUG
 
 from models import db, WindowLog, StatusLog, ReportLog, ApiLog
 
@@ -141,6 +142,8 @@ def receive_log():
     hostname = data.get("hostname")
     username = data.get("username")
 
+    DEBUG(f"/api/log {log_type} from {username}@{hostname}")
+
     # log all requests including invalid ones
     db.session.add(
         ApiLog(
@@ -195,6 +198,8 @@ def report_status():
     username = data.get("username")
     ip = data.get("ip")
     status = data.get("status")
+
+    DEBUG(f"/report {status} from {username}@{hostname}")
 
     db.session.add(
         ApiLog(


### PR DESCRIPTION
## Summary
- add a small `debug_utils.py` helper module
- log basic debugging info in server and agent when `DEBUG` env var is set
- describe `DEBUG` variable in README

## Testing
- `python -m py_compile server.py agent/agent.py debug_utils.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68866afc1cbc832bae94fde65b5c8b5a