### PR TITLE
Fix API log timezone display

### DIFF
--- a/server.py
+++ b/server.py
@@ -60,6 +60,16 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+@app.template_filter("local_time")
+def local_time(value: datetime, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
+    """Format a UTC datetime in local time using TIMEZONE_OFFSET."""
+    if not value:
+        return ""
+    if not isinstance(value, datetime):
+        return str(value)
+    local_dt = value + timedelta(hours=TIMEZONE_OFFSET)
+    return local_dt.strftime(fmt)
+
 def local_now() -> datetime:
     """Return current time adjusted for TIMEZONE_OFFSET."""
     return datetime.utcnow() + timedelta(hours=TIMEZONE_OFFSET)

--- a/templates/api_logs.html
+++ b/templates/api_logs.html
@@ -30,7 +30,7 @@
     <tbody>
       {% for log in logs %}
       <tr>
-        <td>{{ log.created_at }}</td>
+        <td>{{ log.created_at | local_time }}</td>
         <td>{{ log.endpoint }}</td>
         <td>{{ log.username }}</td>
         <td>{{ log.hostname }}</td>


### PR DESCRIPTION
## Summary
- add `local_time` template filter and use TIMEZONE_OFFSET for API log dates
- show API log timestamps in local time

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68866c80a840832b9e9cde4382ca9d52