### PR TITLE
Add real-time window reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ ve uyarı mesajlarını yazar.
 
 ## API Uç Noktaları
 - `POST /api/log` – `log_type` alanı "window" veya "status" olduğunda ilgili verileri kaydeder.
-- `POST /report` – Kullanıcının çevrim içi/çevrim dışı/afk durumunu bildirir.
+- `POST /report` – Kullanıcının çevrim içi/çevrim dışı/afk durumunu veya güncel pencere bilgisini bildirir.
+  - `status` alanı `window` ise `window_title` ve `process_name` gönderilmelidir.
 - `GET /api/statuslogs` – Son 50 durum kaydını JSON olarak döndürür.
 - `GET /api/window_usage` – Belirtilen kullanıcı için pencere kullanım süresi özetini döndürür.
 - `GET /api_logs` – Tüm API isteklerinin ham loglarını görüntüler (sadece admin).

--- a/models.py
+++ b/models.py
@@ -33,6 +33,8 @@ class ReportLog(db.Model):
     username = db.Column(db.String(128))
     ip = db.Column(db.String(64))
     status = db.Column(db.String(32))  # online/offline/keepalive/afk/not-afk
+    window_title = db.Column(db.String(512))
+    process_name = db.Column(db.String(128))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 


### PR DESCRIPTION
## Summary
- add `window_title` and `process_name` columns to `ReportLog`
- extend `/report` to accept window info
- query latest window from `ReportLog` for status page
- send current window updates from agent
- document the new `window` report status

## Testing
- `python -m py_compile server.py models.py debug_utils.py agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68872a1eed5c832b88747e88f7abef97