### PR TITLE
Send queued logs after reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,7 @@ Ayrıca `/`, `/daily_timeline`, `/weekly_report` ve `/usage_report` gibi HTML sa
 ## İstemci (Agent)
 `agent` klasörü, Windows için hazırlanmış örnek istemci uygulamasını içerir. Bu istemci; aktif pencere değişimlerini, klavye/fare etkinliklerini ve AFK durumunu tespit ederek düzenli olarak sunucuya gönderir. VPN bağlantısı `baylan.local` adresine erişilerek kontrol edilir. VPN açık olsa da API sunucusuna ulaşılamazsa arayüzde ayrı bir uyarı gösterilir.
 
+İstemci, sunucuya ulaşılamadığında log kayıtlarını geçici olarak `windowlog.txt` ve `statuslog.txt` dosyalarına yazar. Bağlantı tekrar sağlandığında bu dosyalardaki veriler otomatik olarak sunucuya iletilir ve başarılı gönderilen satırlar silinir.
+
 ## Lisans
 Bu proje MIT lisansı ile dağıtılmaktadır.


### PR DESCRIPTION
## Summary
- keep offline logs in `windowlog.txt` and `statuslog.txt`
- automatically resend stored logs when VPN/server reconnects
- document log resending behaviour in README

## Testing
- `python -m py_compile agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_688734b7ce34832b923142361807a899