### PR TITLE
Implement agent-specific HMAC authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Başlatıldığında sunucu, `LOG_DIR` altında `server.log` dosyasına hata
 ve uyarı mesajlarını yazar.
 
 ## Ortam Değişkenleri
-- `SECRET` – İstemcilerin gönderdiği istekleri doğrulamak için kullanılan anahtar.
+- Artık global `SECRET` anahtarı kullanılmaz. Her istemci `/register` uç noktasından
+  kendisine özel bir anahtar alır ve HMAC imzalı isteklerde bu anahtarı kullanır.
 - `KEEPALIVE_INTERVAL` – Keepalive bildirimlerinin beklenen aralığı (saniye).
 - `OFFLINE_MULTIPLIER` – Kullanıcıyı çevrimdışı kabul etmeden önce beklenen keepalive süresinin kaç katı süre geçmesi gerektiği.
 - `MONITOR_INTERVAL` – Arka plan izleme iş parçacığının kontrol aralığı (saniye).
@@ -41,6 +42,7 @@ ve uyarı mesajlarını yazar.
 - `DEBUG` – `1` veya `true` ise ek hata ayıklama mesajları loglanır.
 
 ## API Uç Noktaları
+- `POST /register` – İstemciye benzersiz bir gizli anahtar döner.
 - `POST /api/log` – `log_type` alanı "window" veya "status" olduğunda ilgili verileri kaydeder.
 - `POST /report` – Kullanıcının çevrim içi/çevrim dışı/afk durumunu veya güncel pencere bilgisini bildirir.
   - `status` alanı `window` ise `window_title` ve `process_name` gönderilmelidir.

--- a/models.py
+++ b/models.py
@@ -47,3 +47,15 @@ class ApiLog(db.Model):
     username = db.Column(db.String(128))
     payload = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class AgentSecret(db.Model):
+    """Per-agent secret used for request authentication."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    hostname = db.Column(db.String(128))
+    username = db.Column(db.String(128))
+    secret = db.Column(db.String(64))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    __table_args__ = (db.UniqueConstraint("hostname", "username", name="u_agent"),)


### PR DESCRIPTION
## Summary
- store per-agent secrets in new `AgentSecret` table
- expose `/register` endpoint that hands out secrets
- validate `X-Signature` HMAC on `/api/log` and `/report`
- update agent to obtain secret on first start and sign all requests
- document new workflow in the README

## Testing
- `python -m py_compile server.py agent/agent.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_688739abf694832baaf44a2fef28a0c4