### PR TITLE
Add real-time update for panel

### DIFF
--- a/server.py
+++ b/server.py
@@ -966,6 +966,17 @@ def api_today_totals():
     return jsonify(details)
 
 
+@app.route("/api/current_status")
+@login_required
+def api_current_status():
+    """Return current online/afk status list used on the main panel."""
+    status_list = get_current_status()
+    if not is_admin():
+        user = session.get("user")
+        status_list = [s for s in status_list if s["username"] == user]
+    return jsonify(status_list)
+
+
 def get_weekly_report(username: str, week_start: date):
     """Return daily online/active/afk totals for given user and week."""
     results = []

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
             <th>Bugün Toplam</th>
         </tr>
     </thead>
-    <tbody>
+    <tbody id="status-table-body">
         {% for row in status_list %}
         <tr>
             <td>{{ row.username }}</td>
@@ -52,5 +52,37 @@
   <a class="btn btn-primary" href="/usage_report" style="margin-left:10px">Kullanım Raporları</a>
   <a class="btn btn-info" href="/daily_timeline" style="margin-left:10px">Zaman Çizelgesi</a>
 </div>
+<script>
+function formatDuration(sec){
+    sec = Math.floor(sec || 0);
+    const h = Math.floor(sec / 3600);
+    const m = Math.floor((sec % 3600) / 60);
+    return h + ':' + String(m).padStart(2, '0');
+}
+
+function updateStatus(){
+    fetch('/api/current_status')
+        .then(r => r.json())
+        .then(rows => {
+            const tbody = document.getElementById('status-table-body');
+            tbody.innerHTML = '';
+            rows.forEach(row => {
+                const tr = document.createElement('tr');
+                tr.innerHTML =
+                    `<td>${row.username}</td>`+
+                    `<td>${row.hostname}</td>`+
+                    `<td>${row.badge}</td>`+
+                    `<td>${row.window_title}</td>`+
+                    `<td>${row.shown_status}</td>`+
+                    `<td>${row.ip}</td>`+
+                    `<td>${formatDuration(row.today_active)}</td>`+
+                    `<td>${formatDuration(row.today_total)}</td>`;
+                tbody.appendChild(tr);
+            });
+        });
+}
+
+setInterval(updateStatus, 60000);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/api/current_status` endpoint that returns the same data as the main panel
- update the panel's table body element id for JavaScript manipulation
- add client-side script to poll new status data every minute and refresh table

## Testing
- `python -m py_compile server.py agent/agent.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68873cc20788832b9f10b8731ff458a6