### PR TITLE
Improve time display in weekly report

### DIFF
--- a/server.py
+++ b/server.py
@@ -1076,8 +1076,8 @@ def generate_all_weekly_tables():
     for username, rows in all_reports.items():
         table_rows = "".join(
             f"<tr><td>{r['date']}</td>"
-            f"<td>{local_time(r['start']) if r['start'] else ''}</td>"
-            f"<td>{local_time(r['end']) if r['end'] else ''}</td>"
+            f"<td>{local_time(r['start'], '%H:%M') if r['start'] else ''}</td>"
+            f"<td>{local_time(r['end'], '%H:%M') if r['end'] else ''}</td>"
             f"<td>{format_duration(r['online'])}</td>"
             f"<td>{format_duration(r['active'])}</td>"
             f"<td>{format_duration(r['afk'])}</td></tr>"

--- a/templates/weekly_report.html
+++ b/templates/weekly_report.html
@@ -46,8 +46,8 @@
       {% for r in report_rows %}
       <tr>
         <td>{{ r.date }}</td>
-        <td>{{ r.start | local_time if r.start }}</td>
-        <td>{{ r.end | local_time if r.end }}</td>
+        <td>{{ r.start | local_time('%H:%M') if r.start }}</td>
+        <td>{{ r.end | local_time('%H:%M') if r.end }}</td>
         <td>{{ format_duration(r.online) }}</td>
         <td>{{ format_duration(r.active) }}</td>
         <td>{{ format_duration(r.afk) }}</td>


### PR DESCRIPTION
## Summary
- keep only time for start and end columns in weekly report table
- match time-only format in admin HTML tables

## Testing
- `python -m py_compile server.py models.py debug_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68874d28b47c832bbe73a4e569c5a611