### PR TITLE
Improve offline detection when agent disconnects

### DIFF
--- a/server.py
+++ b/server.py
@@ -406,13 +406,13 @@ def monitor_keepalive():
                 if last_state:
                     start_time = last_state.created_at
                     status = last_state.status
-                    duration = int((rep.created_at - start_time).total_seconds())
+                    duration = int((now - start_time).total_seconds())
                     sl = StatusLog(
                         hostname=rep.hostname,
                         username=rep.username,
                         status=status,
                         start_time=start_time.isoformat(),
-                        end_time=rep.created_at.isoformat(),
+                        end_time=now.isoformat(),
                         duration=duration,
                     )
                     db.session.add(sl)


### PR DESCRIPTION
## Summary
- ensure background monitor logs status up to offline detection

## Testing
- `python -m py_compile server.py models.py agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6887529b029c832b88a3eb75bceb54ee