### PR TITLE
Bring window forward when server unreachable

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -688,6 +688,10 @@ class MainWindow(QWidget):
             elif not server_ok:
                 self.status_label.setText("Durum: API Sunucusu Yok")
                 self.logla("VPN var ancak API sunucusuna erişilemiyor.")
+                # Pencere kücültülmüş olsa bile ön plana çıkart
+                self.showNormal()
+                self.raise_()
+                self.activateWindow()
             else:
                 if self.forticlient_window_shown or not was_vpn:
                     self.logla("VPN bağlantısı tekrar sağlandı.")


### PR DESCRIPTION
## Summary
- ensure minimized agent window is shown when the API server is unreachable

## Testing
- `python -m py_compile agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68875abfd8a4832b81e85f063d6b7256