### PR TITLE
Remove API status logs section

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,6 @@
         {% endfor %}
     </tbody>
   </table>
-  <a class="btn btn-secondary" href="/api/statuslogs">API: Status Logs</a>
   {% if session.get('is_admin') %}
   <a class="btn btn-warning" href="/api_logs" style="margin-left:10px">API Logs</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- remove API Status Logs button from the panel

## Testing
- `python -m py_compile server.py models.py debug_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68876a659ef8832bbd825aea980d3819