### PR TITLE
Fix drawing rect with floats in PyQt

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -461,7 +461,9 @@ class NetworkWidget(QWidget):
         painter.setPen(Qt.black)
         painter.setBrush(Qt.lightGray)
         painter.drawRect(comp_rect)
-        painter.drawRect(comp_center.x() - 10, comp_center.y() + 15, 20, 5)
+        # QRectF kullanarak float koordinatlarla çizmeye izin ver
+        stand_rect = QRectF(comp_center.x() - 10, comp_center.y() + 15, 20, 5)
+        painter.drawRect(stand_rect)
 
         # draw world icon
         painter.setBrush(Qt.lightGray)


### PR DESCRIPTION
## Summary
- fix a TypeError when drawing the stand of the computer icon in `NetworkWidget`

## Testing
- `python3 -m py_compile agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_688776a601d4832b8f607663da891e4d