### PR TITLE
Add filter & search to API log and usage pages

### DIFF
--- a/templates/api_logs.html
+++ b/templates/api_logs.html
@@ -17,6 +17,30 @@
     <a class="btn btn-secondary me-3" href="/">Geri Dön</a>
     <h2 class="mb-0">API Logları</h2>
   </div>
+  <form method="get" class="row mb-3">
+    <div class="col">
+      <select name="username" class="form-select">
+        <option value="">Tüm Kullanıcılar</option>
+        {% for u in usernames %}
+        <option value="{{ u }}" {% if u == selected_user %}selected{% endif %}>{{ u }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col">
+      <select name="endpoint" class="form-select">
+        <option value="">Tüm Endpointler</option>
+        {% for e in endpoints %}
+        <option value="{{ e }}" {% if e == selected_endpoint %}selected{% endif %}>{{ e }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col">
+      <input type="text" name="q" class="form-control" placeholder="Ara" value="{{ q }}">
+    </div>
+    <div class="col">
+      <button class="btn btn-primary" type="submit">Filtrele</button>
+    </div>
+  </form>
   <table class="table table-bordered table-striped shadow">
     <thead class="table-dark">
       <tr>

--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -35,6 +35,9 @@
       <input type="date" name="date" class="form-control" value="{{ base_date.isoformat() }}">
     </div>
     <div class="col">
+      <input type="text" name="q" class="form-control" placeholder="Ara" value="{{ q }}">
+    </div>
+    <div class="col">
       <button class="btn btn-primary" type="submit">Göster</button>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- allow filtering by username, endpoint and search text on API Logs page
- filter usage report rows with a search term
- add simple form controls to API Logs and Usage pages for search

## Testing
- `python -m py_compile server.py awlog_server/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885fbf1064832b93a1a47bb88d071a