### PR TITLE
Fix keepalive monitor offline duration

### DIFF
--- a/server.py
+++ b/server.py
@@ -302,18 +302,21 @@ def monitor_keepalive():
                 )
 
                 if last_state:
-                    start_time = last_state.created_at
                     status = last_state.status
-                    duration = int((now - start_time).total_seconds())
-                    sl = StatusLog(
-                        hostname=rep.hostname,
-                        username=rep.username,
-                        status=status,
-                        start_time=start_time.isoformat(),
-                        end_time=now.isoformat(),
-                        duration=duration,
-                    )
-                    db.session.add(sl)
+                else:
+                    status = "not-afk"
+
+                start_time = rep.created_at
+                duration = int((now - start_time).total_seconds())
+                sl = StatusLog(
+                    hostname=rep.hostname,
+                    username=rep.username,
+                    status=status,
+                    start_time=start_time.isoformat(),
+                    end_time=now.isoformat(),
+                    duration=duration,
+                )
+                db.session.add(sl)
 
                 offline = ReportLog(
                     hostname=rep.hostname,


### PR DESCRIPTION
## Summary
- fix incorrect offline duration calculation when keepalive stops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886587544c832bab445e65422cc83c