### PR TITLE
Fix monitor thread startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,5 @@ services:
       - ./data:/app/data
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - FLASK_ENV=production
+      - FLASK_DEBUG=0
       - TZ=Europe/Istanbul

--- a/server.py
+++ b/server.py
@@ -43,7 +43,6 @@ def start_monitor_thread():
         monitor_thread = threading.Thread(target=monitor_keepalive, daemon=True)
         monitor_thread.start()
 
-start_monitor_thread()
 
 @app.before_first_request
 def setup_db():
@@ -1098,4 +1097,5 @@ def api_logs():
     )
 
 if __name__ == "__main__":
+    start_monitor_thread()
     app.run(host="0.0.0.0", port=5050)


### PR DESCRIPTION
## Summary
- ensure background monitor thread starts after the function is defined
- update docker compose to use `FLASK_DEBUG` instead of deprecated `FLASK_ENV`

## Testing
- `python -m py_compile server.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68886e625990832ba4d61ecf0c1c7f13