### PR TITLE
Enable date and payload filtering for API logs

### DIFF
--- a/templates/api_logs.html
+++ b/templates/api_logs.html
@@ -38,6 +38,18 @@
       <input type="text" name="q" class="form-control" placeholder="Ara" value="{{ q }}">
     </div>
     <div class="col">
+      <input type="datetime-local" name="start" class="form-control" value="{{ start }}">
+    </div>
+    <div class="col">
+      <input type="datetime-local" name="end" class="form-control" value="{{ end }}">
+    </div>
+    <div class="col">
+      <input type="text" name="field" class="form-control" placeholder="Alan" value="{{ field }}">
+    </div>
+    <div class="col">
+      <input type="text" name="value" class="form-control" placeholder="Değer" value="{{ value }}">
+    </div>
+    <div class="col">
       <button class="btn btn-primary" type="submit">Filtrele</button>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- extend `/api_logs` with optional `start`/`end` datetime filters
- allow filtering by JSON payload fields
- surface the new parameters in the API logs form

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68887b1e9e94832ba3265538bc3dc546