### PR TITLE
Improve API log filtering UI

### DIFF
--- a/server.py
+++ b/server.py
@@ -1123,6 +1123,16 @@ def api_logs():
     usernames = [u[0] for u in db.session.query(ApiLog.username).distinct()]
     endpoints = [e[0] for e in db.session.query(ApiLog.endpoint).distinct()]
 
+    payload_fields = set()
+    for log in logs:
+        try:
+            data = json.loads(log.payload)
+            if isinstance(data, dict):
+                payload_fields.update(data.keys())
+        except Exception:
+            continue
+    payload_fields = sorted(payload_fields)
+
     return render_template(
         "api_logs.html",
         logs=logs,
@@ -1135,6 +1145,7 @@ def api_logs():
         end=end_param or "",
         field=payload_field or "",
         value=payload_value or "",
+        payload_fields=payload_fields,
     )
 
 if __name__ == "__main__":

--- a/templates/api_logs.html
+++ b/templates/api_logs.html
@@ -17,40 +17,51 @@
     <a class="btn btn-secondary me-3" href="/">Geri Dön</a>
     <h2 class="mb-0">API Logları</h2>
   </div>
-  <form method="get" class="row mb-3">
-    <div class="col">
-      <select name="username" class="form-select">
-        <option value="">Tüm Kullanıcılar</option>
-        {% for u in usernames %}
-        <option value="{{ u }}" {% if u == selected_user %}selected{% endif %}>{{ u }}</option>
-        {% endfor %}
-      </select>
+  <form method="get" class="mb-3">
+    <div class="row mb-2">
+      <div class="col">
+        <select name="username" class="form-select">
+          <option value="">Tüm Kullanıcılar</option>
+          {% for u in usernames %}
+          <option value="{{ u }}" {% if u == selected_user %}selected{% endif %}>{{ u }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col">
+        <select name="endpoint" class="form-select">
+          <option value="">Tüm Endpointler</option>
+          {% for e in endpoints %}
+          <option value="{{ e }}" {% if e == selected_endpoint %}selected{% endif %}>{{ e }}</option>
+          {% endfor %}
+        </select>
+      </div>
     </div>
-    <div class="col">
-      <select name="endpoint" class="form-select">
-        <option value="">Tüm Endpointler</option>
-        {% for e in endpoints %}
-        <option value="{{ e }}" {% if e == selected_endpoint %}selected{% endif %}>{{ e }}</option>
-        {% endfor %}
-      </select>
+    <div class="row mb-2">
+      <div class="col">
+        <input type="text" name="q" class="form-control" placeholder="Ara" value="{{ q }}">
+      </div>
+      <div class="col">
+        <input type="datetime-local" name="start" class="form-control" value="{{ start }}">
+      </div>
+      <div class="col">
+        <input type="datetime-local" name="end" class="form-control" value="{{ end }}">
+      </div>
     </div>
-    <div class="col">
-      <input type="text" name="q" class="form-control" placeholder="Ara" value="{{ q }}">
-    </div>
-    <div class="col">
-      <input type="datetime-local" name="start" class="form-control" value="{{ start }}">
-    </div>
-    <div class="col">
-      <input type="datetime-local" name="end" class="form-control" value="{{ end }}">
-    </div>
-    <div class="col">
-      <input type="text" name="field" class="form-control" placeholder="Alan" value="{{ field }}">
-    </div>
-    <div class="col">
-      <input type="text" name="value" class="form-control" placeholder="Değer" value="{{ value }}">
-    </div>
-    <div class="col">
-      <button class="btn btn-primary" type="submit">Filtrele</button>
+    <div class="row mb-2">
+      <div class="col">
+        <select name="field" class="form-select">
+          <option value="">Payload Alanı</option>
+          {% for f in payload_fields %}
+          <option value="{{ f }}" {% if f == field %}selected{% endif %}>{{ f }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col">
+        <input type="text" name="value" class="form-control" placeholder="Değer" value="{{ value }}">
+      </div>
+      <div class="col">
+        <button class="btn btn-primary w-100" type="submit">Filtrele</button>
+      </div>
     </div>
   </form>
   <table class="table table-bordered table-striped shadow">


### PR DESCRIPTION
## Summary
- split API log filter form into multiple rows
- populate payload field dropdown from log data

## Testing
- `python -m py_compile server.py awlog_server/*.py agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68887d7ada08832b9260b503bea7eea0