### PR TITLE
Fix timezone in API log date filters

### DIFF
--- a/server.py
+++ b/server.py
@@ -1099,15 +1099,16 @@ def api_logs():
             | ApiLog.username.ilike(search)
             | ApiLog.hostname.ilike(search)
         )
+    offset = app.config.get("TIMEZONE_OFFSET", 0)
     if start_param:
         try:
-            start_dt = datetime.fromisoformat(start_param)
+            start_dt = datetime.fromisoformat(start_param) - timedelta(hours=offset)
             query = query.filter(ApiLog.created_at >= start_dt)
         except ValueError:
             pass
     if end_param:
         try:
-            end_dt = datetime.fromisoformat(end_param)
+            end_dt = datetime.fromisoformat(end_param) - timedelta(hours=offset)
             query = query.filter(ApiLog.created_at <= end_dt)
         except ValueError:
             pass


### PR DESCRIPTION
## Summary
- adjust `/api_logs` filter parameters to convert local datetime inputs to UTC

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688881505888832ba5788d9cb6d36fd2