### PR TITLE
Add login page logo

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -10,6 +10,9 @@
 </head>
 <body>
 <div class="login-form">
+  <div class="text-center mb-3">
+    <img src="images/baylan-evden-calisma-logo.svg" alt="Logo" style="max-height: 100px;">
+  </div>
   <h2>Giriş Yap</h2>
   {% with messages = get_flashed_messages() %}
     {% if messages %}


### PR DESCRIPTION
## Summary
- display `baylan-evden-calisma-logo.svg` at the top of the login form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888cbce6d2c832b8c763cdae5a41728