### PR TITLE
Reduce macro-suspect sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Ayrıca `/`, `/daily_timeline`, `/weekly_report` ve `/usage_report` gibi HTML sa
 `agent` klasörü, Windows için hazırlanmış örnek istemci uygulamasını içerir. Bu istemci; aktif pencere değişimlerini, klavye/fare etkinliklerini ve AFK durumunu tespit ederek düzenli olarak sunucuya gönderir. VPN bağlantısı `baylan.local` adresine erişilerek kontrol edilir. VPN açık olsa da API sunucusuna ulaşılamazsa arayüzde ayrı bir uyarı gösterilir.
 
 Ek olarak kullanıcı girişlerinin çok düzenli aralıklarla gerçekleşip gerçekleşmediği izlenir. Bu tür tutarlılık tespit edildiğinde sunucuya `macro-suspect` bildirimi gönderilerek olası makro kullanımı raporlanır.
-Varsayılan olarak 30 saniyenin altındaki düzenli girdi aralıkları analiz edilir ve 10 ardışık girişte ciddi bir tutarlılık tespit edilirse makro şüphesi raporlanır.
+Varsayılan olarak 15 saniyenin altındaki düzenli girdi aralıkları analiz edilir ve 20 ardışık girişte ciddi bir tutarlılık tespit edilirse makro şüphesi raporlanır.
 
 İstemci, sunucuya ulaşılamadığında log kayıtlarını geçici olarak `windowlog.txt` ve `statuslog.txt` dosyalarına yazar. Bağlantı tekrar sağlandığında bu dosyalardaki veriler otomatik olarak sunucuya iletilir ve başarılı gönderilen satırlar silinir. Bu iletim işlemleri artık asenkron HTTP çağrıları kullanılarak gerçekleşir.
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -143,9 +143,12 @@ pressed_keys = set()
 
 # --- Makro Kullanımını Tespit İçin Girdi Zamanları ---
 input_times = []
-MACRO_CHECK_COUNT = 10  # kontrol için gereken minimum girdi sayısı
-MACRO_STD_THRESHOLD = 0.05  # standart sapmanın ortalamaya oranı
-MACRO_MIN_INTERVAL = 30.0  # saniye
+# Makro tespiti için gereken minimum ardışık girdi sayısı
+MACRO_CHECK_COUNT = 20
+# Ortalama aralığa göre kabul edilecek standart sapma oranı
+MACRO_STD_THRESHOLD = 0.10
+# Kontrol edilecek maksimum ortalama girdi aralığı (saniye)
+MACRO_MIN_INTERVAL = 15.0
 
 # Makro kullanımını tespit etmek için son giriş zamanlarını analiz eder
 def check_macro_pattern(timestamp: float) -> None:


### PR DESCRIPTION
## Summary
- tune macro detection logic to require 20 consistent inputs with intervals under 15s and allow 10% variance
- update README to reflect the new defaults

## Testing
- `python -m py_compile agent/agent.py server.py awlog_server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6888deec9e7c832bbebba5a3efd4a8a2