### PR TITLE
Reduce false macro detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Ayrıca `/`, `/daily_timeline`, `/weekly_report` ve `/usage_report` gibi HTML sa
 
 Ek olarak kullanıcı girişlerinin çok düzenli aralıklarla gerçekleşip gerçekleşmediği izlenir. Bu tür tutarlılık tespit edildiğinde sunucuya `macro-suspect` bildirimi gönderilerek olası makro kullanımı raporlanır.
 Varsayılan olarak 15 saniyenin altındaki düzenli girdi aralıkları analiz edilir ve 20 ardışık girişte ciddi bir tutarlılık tespit edilirse makro şüphesi raporlanır.
+Fare hareketleri çok sık tetiklendiğinden bu hareketler makro denetimine dahil edilmez; yalnızca klavye ve tıklama gibi temel girdiler değerlendirilir.
 
 İstemci, sunucuya ulaşılamadığında log kayıtlarını geçici olarak `windowlog.txt` ve `statuslog.txt` dosyalarına yazar. Bağlantı tekrar sağlandığında bu dosyalardaki veriler otomatik olarak sunucuya iletilir ve başarılı gönderilen satırlar silinir. Bu iletim işlemleri artık asenkron HTTP çağrıları kullanılarak gerçekleşir.
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -274,12 +274,17 @@ def log_status_period(start_time, end_time, status):
     log_queue.put(("status", data))
     update_today_counters(cur_start, end_time, status)
 
-def input_event():
-    """Gerçek bir kullanıcı girdisi olduğunda çağrılır."""
+def input_event(check_macro: bool = True):
+    """Gerçek bir kullanıcı girdisi olduğunda çağrılır.
+
+    ``check_macro`` parametresi ``False`` ise makro tespiti yapılmaz. Bu seçenek
+    sık aralıklarla tetiklenen fare hareketlerinde kullanılır.
+    """
     global last_input_time, afk_state, afk_period_start, notafk_period_start, LOG_CALLBACK
     now = time.time()
     last_input_time = now
-    check_macro_pattern(now)
+    if check_macro:
+        check_macro_pattern(now)
     if afk_state:
         afk_period_end = datetime.now()
         log_status_period(afk_period_start, afk_period_end, "afk")
@@ -302,7 +307,7 @@ def on_key_release(key):
 
 def start_listeners():
     mouse.Listener(
-        on_move=lambda *a, **k: input_event(),
+        on_move=lambda *a, **k: input_event(False),
         on_click=lambda *a, **k: input_event(),
         on_scroll=lambda *a, **k: input_event(),
     ).start()

--- a/agent/service_agent.py
+++ b/agent/service_agent.py
@@ -219,11 +219,12 @@ def log_status_period(start_time, end_time, status):
     log_queue.put(("status", data))
 
 
-def input_event():
+def input_event(check_macro: bool = True):
     global last_input_time, afk_state, afk_period_start, notafk_period_start
     now = time.time()
     last_input_time = now
-    check_macro_pattern(now)
+    if check_macro:
+        check_macro_pattern(now)
     if afk_state:
         afk_end = datetime.now()
         log_status_period(afk_period_start, afk_end, "afk")
@@ -245,7 +246,7 @@ def on_key_release(key):
 
 def start_listeners():
     mouse.Listener(
-        on_move=lambda *a, **k: input_event(),
+        on_move=lambda *a, **k: input_event(False),
         on_click=lambda *a, **k: input_event(),
         on_scroll=lambda *a, **k: input_event(),
     ).start()


### PR DESCRIPTION
## Summary
- ignore mouse movement events when checking for macro usage
- document that macro detection skips mouse moves

## Testing
- `python -m py_compile agent/agent.py agent/service_agent.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_6888e12712d4832bb37cf9fb633e87c7