### PR TITLE
Load macro recorder lists from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+MACRO_PROC_BLACKLIST=tinytask.exe,macrorecorder.exe,pulover's macro creator.exe
+MACRO_PROC_WHITELIST=
+MACRO_PROC_CHECK_INTERVAL=10

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ ve uyarı mesajlarını yazar.
   sayısı (varsayılan 30).
 - `LOG_DIR` – Sunucu günlüklerinin yazılacağı klasör (varsayılan `logs`).
 - `DEBUG` – `1` veya `true` ise ek hata ayıklama mesajları loglanır.
+- `MACRO_PROC_BLACKLIST` – Makro kaydedici olarak kabul edilen işlem
+  isimlerinin virgülle ayrılmış listesi.
+- `MACRO_PROC_WHITELIST` – Tespit edilse de yoksayılacak işlem
+  isimlerinin virgülle ayrılmış listesi.
+- `MACRO_PROC_CHECK_INTERVAL` – Süreç listesinin kaç saniyede bir
+  taranacağı (varsayılan 10).
 
 ## API Uç Noktaları
 - `POST /register` – İstemciye benzersiz bir gizli anahtar döner.


### PR DESCRIPTION
## Summary
- pull macro recorder blacklist/whitelist from environment variables
- document new environment variables
- provide `.env.example`

## Testing
- `python -m py_compile agent/agent.py agent/service_agent.py server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889b87990d0832baa12300808824304