### PR TITLE
Add UIA URL extraction for Windows agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ve uyarı mesajlarını yazar.
 Ayrıca `/`, `/daily_timeline`, `/weekly_report` ve `/usage_report` gibi HTML sayfaları mevcuttur.
 
 ## İstemci (Agent)
-`agent` klasörü, Windows için hazırlanmış örnek istemci uygulamasını içerir. Bu istemci; aktif pencere değişimlerini izler, sistemdeki son giriş zamanını ve ağ trafiğini değerlendirerek AFK durumunu tahmin eder ve bu verileri düzenli olarak sunucuya gönderir. Windows kilitlenirse AFK durumu anında bildirilir. VPN bağlantısı `baylan.local` adresine erişilerek kontrol edilir. VPN açık olsa da API sunucusuna ulaşılamazsa arayüzde ayrı bir uyarı gösterilir.
+`agent` klasörü, Windows için hazırlanmış örnek istemci uygulamasını içerir. Bu istemci; aktif pencere değişimlerini izler, sistemdeki son giriş zamanını ve ağ trafiğini değerlendirerek AFK durumunu tahmin eder ve bu verileri düzenli olarak sunucuya gönderir. Tarayıcı pencerelerindeki URL'leri okuyabilmek için `pywinauto` kütüphanesini kullanır. Windows kilitlenirse AFK durumu anında bildirilir. VPN bağlantısı `baylan.local` adresine erişilerek kontrol edilir. VPN açık olsa da API sunucusuna ulaşılamazsa arayüzde ayrı bir uyarı gösterilir.
 
 AFK tespiti icin istemci, varsayilan olarak 60 saniyelik `afk_timeout` ve 1 MB (1.048.576 bayt) `net_active_threshold` degerlerini kullanir. Kucuk ama surekli ag trafiginin yanlis sonuclara yol acmamasi icin son `net_active_window` suresinde (varsayilan 5 saniye) biriken baytlarin toplami bu esigi asmadikca AFK durumuna gecilmez. Bu parametreleri `agent/agent.py` dosyasindaki sabitlerden dilediginiz gibi ayarlayabilirsiniz.
 Ek olarak çalışmakta olan süreçler kara listeye göre taranarak bilinen makro kaydedici programlar tespit edilmeye çalışılır ve gerekirse `macro-suspect` bildirimi gönderilir.

--- a/agent/service_agent.py
+++ b/agent/service_agent.py
@@ -234,6 +234,31 @@ def extract_domain(title: str) -> str | None:
     return None
 
 
+def get_browser_url(pid: int) -> str | None:
+    """Return URL from browser's address bar using UI Automation."""
+    try:
+        import pywinauto
+    except Exception:
+        return None
+
+    try:
+        app = pywinauto.Application(backend="uia").connect(process=pid)
+        dlg = app.top_window()
+        for el in dlg.descendants(control_type="Edit"):
+            try:
+                val = el.get_value()
+                if isinstance(val, str) and val.startswith("http"):
+                    return val
+                txt = el.window_text()
+                if isinstance(txt, str) and txt.startswith("http"):
+                    return txt
+            except Exception:
+                continue
+    except Exception:
+        return None
+    return None
+
+
 def get_active_window_info():
     try:
         import win32gui
@@ -246,9 +271,13 @@ def get_active_window_info():
         proc_lower = process_name.lower()
         browsers = {"chrome.exe", "msedge.exe", "firefox.exe", "opera.exe", "iexplore.exe"}
         if proc_lower in browsers:
-            domain = extract_domain(window_title)
-            if domain:
-                window_title = domain
+            url = get_browser_url(pid)
+            if url:
+                window_title = url
+            else:
+                domain = extract_domain(window_title)
+                if domain:
+                    window_title = domain
         return window_title, process_name
     except Exception:
         return None, None


### PR DESCRIPTION
## Summary
- extract active tab URL from the address bar using pywinauto
- fall back to domain extraction if URL is unavailable
- document pywinauto requirement for the agent

## Testing
- `python -m py_compile agent/agent.py agent/service_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_688a0eb134b0832b944a7e62a016c99e