### PR TITLE
Fix empty window log values

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -376,40 +376,61 @@ def schedule_browser_url_read(pid: int, hwnd: int) -> None:
 
 
 def get_active_window_info():
+    """Return active window title and process name.
+
+    Exceptions while fetching browser URLs or process names should not
+    cause the whole result to be ``None`` so that logs don't end up with
+    empty fields."""
+
     global last_was_browser
+
     try:
         import win32gui
         import win32process
-        hwnd = win32gui.GetForegroundWindow()
-        window_title = win32gui.GetWindowText(hwnd)
+    except Exception as e:
+        DEBUG(f"get_active_window_info import error: {e}")
+        return None, None, False
+
+    hwnd = win32gui.GetForegroundWindow()
+    window_title = win32gui.GetWindowText(hwnd)
+
+    process_name = None
+    try:
         _, pid = win32process.GetWindowThreadProcessId(hwnd)
         process = psutil.Process(pid)
         process_name = process.name()
-        proc_lower = process_name.lower()
-        browsers = {"chrome.exe", "msedge.exe", "firefox.exe", "opera.exe", "iexplore.exe"}
-        url_updated = False
-        if proc_lower in browsers:
-            schedule_browser_url_read(pid, hwnd)
-            with browser_lock:
-                url = browser_url
-                new = browser_url_new
-                if new:
-                    browser_url_new = False
-            if url:
-                window_title = url
-                if new:
-                    url_updated = True
+    except Exception as e:
+        DEBUG(f"get_active_window_info process error: {e}")
+
+    url_updated = False
+    try:
+        if process_name:
+            proc_lower = process_name.lower()
+            browsers = {"chrome.exe", "msedge.exe", "firefox.exe", "opera.exe", "iexplore.exe"}
+            if proc_lower in browsers:
+                schedule_browser_url_read(pid, hwnd)
+                with browser_lock:
+                    url = browser_url
+                    new = browser_url_new
+                    if new:
+                        browser_url_new = False
+                if url:
+                    window_title = url
+                    if new:
+                        url_updated = True
+                else:
+                    domain = extract_domain(window_title)
+                    if domain:
+                        window_title = domain
+                last_was_browser = True
             else:
-                domain = extract_domain(window_title)
-                if domain:
-                    window_title = domain
-            last_was_browser = True
-        else:
-            last_was_browser = False
-        window_title = simplify_window_title(window_title)
-        return window_title, process_name, url_updated
-    except Exception:
-        return None, None, False
+                last_was_browser = False
+    except Exception as e:
+        DEBUG(f"get_active_window_info browser error: {e}")
+        last_was_browser = False
+
+    window_title = simplify_window_title(window_title)
+    return window_title, process_name, url_updated
 
 def get_idle_seconds() -> float:
     class LASTINPUTINFO(ctypes.Structure):


### PR DESCRIPTION
## Summary
- handle partial failures when retrieving window information
- log errors but still return available window titles/process names

## Testing
- `python -m py_compile agent/agent.py agent/service_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_688a6e4bb5bc832b87bbd9e08ee67925