### PR TITLE
Improve browser window reporting

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -402,6 +402,15 @@ def get_active_window_info():
     except Exception as e:
         DEBUG(f"get_active_window_info process error: {e}")
 
+    # Hemen elde edebiliyorsak URL'i senkron olarak oku
+    if not window_title and process_name:
+        try:
+            url = get_browser_url(pid)
+            if url:
+                window_title = url
+        except Exception as e:
+            DEBUG(f"get_active_window_info url sync error: {e}")
+
     url_updated = False
     try:
         if process_name:


### PR DESCRIPTION
## Summary
- capture browser URL synchronously when title is empty
- normalize window titles and process names in the service agent

## Testing
- `python -m py_compile agent/agent.py agent/service_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_688a709803dc832bbba754522a9aa71d