### PR TITLE
Improve browser URL detection caching

### DIFF
--- a/agent/service_agent.py
+++ b/agent/service_agent.py
@@ -234,12 +234,19 @@ def extract_domain(title: str) -> str | None:
     return None
 
 
+_BROWSER_URL_CACHE: dict[int, tuple[str, float]] = {}
+
 def get_browser_url(pid: int) -> str | None:
     """Return URL from browser's address bar using UI Automation."""
     try:
         import pywinauto
     except Exception:
         return None
+
+    now = time.time()
+    cached = _BROWSER_URL_CACHE.get(pid)
+    if cached and now - cached[1] < 3.0:
+        return cached[0]
 
     try:
         app = pywinauto.Application(backend="uia").connect(process=pid)
@@ -248,9 +255,11 @@ def get_browser_url(pid: int) -> str | None:
             try:
                 val = el.get_value()
                 if isinstance(val, str) and val.startswith("http"):
+                    _BROWSER_URL_CACHE[pid] = (val, now)
                     return val
                 txt = el.window_text()
                 if isinstance(txt, str) and txt.startswith("http"):
+                    _BROWSER_URL_CACHE[pid] = (txt, now)
                     return txt
             except Exception:
                 continue


### PR DESCRIPTION
## Summary
- cache browser URL lookups in the Windows agent
- reuse cached URLs for a short time to avoid heavy UI Automation calls

## Testing
- `python -m py_compile agent/agent.py agent/service_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_688a747b8378832b89e82b945a38cddf