### PR TITLE
Fix missing os import causing NameError

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,6 +19,7 @@ import logging
 import hmac
 import hashlib
 import secrets
+import os
 from debug_utils import DEBUG
 
 from awlog_server.models import db, WindowLog, StatusLog, ReportLog, ApiLog, AgentSecret


### PR DESCRIPTION
## Summary
- add missing `import os` in server.py

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_688b07e0ff78832b85270bd4fc682e66