### PR TITLE
Only store URL domain

### DIFF
--- a/agent/service_agent.py
+++ b/agent/service_agent.py
@@ -13,6 +13,7 @@ import getpass
 import socket
 import hmac
 import hashlib
+from urllib.parse import urlparse
 from datetime import datetime, timedelta
 import ctypes
 
@@ -51,6 +52,22 @@ def get_hostname():
 
 def get_username():
     return getpass.getuser()
+
+
+def domain_from_url(url: str | None) -> str | None:
+    if not url:
+        return url
+    url = url.strip()
+    try:
+        if '://' not in url:
+            url = '//' + url
+        parsed = urlparse(url)
+        host = parsed.hostname
+        if host:
+            return host.lower()
+        return url.split('/')[0].split(':')[0].lower()
+    except Exception:
+        return url
 
 
 def load_secret():
@@ -151,7 +168,7 @@ async def _report_window(window_title, process_name, url):
         "status": "window",
         "window_title": window_title or "",
         "process_name": process_name or "",
-        "url": url or "",
+        "url": domain_from_url(url) or "",
     }
     try:
         load_secret()
@@ -212,7 +229,7 @@ def log_window_period(window_title, process_name, url, start_time, end_time):
         "start_time": start_time.isoformat(),
         "end_time": end_time.isoformat(),
         "duration": duration,
-        "url": url or "",
+        "url": domain_from_url(url) or "",
     }
     log_queue.put(("window", data))
 

--- a/awlog_server/utils.py
+++ b/awlog_server/utils.py
@@ -4,6 +4,7 @@ import ldap3
 import re
 from datetime import datetime, timedelta
 from functools import wraps
+from urllib.parse import urlparse
 from flask import session, redirect, url_for, request, current_app
 
 
@@ -83,3 +84,20 @@ def get_app_from_window(title: str, process: str) -> str:
         if parts:
             return parts[0].lower()
     return proc or "unknown"
+
+
+def domain_from_url(url: str | None) -> str | None:
+    """Extract hostname from URL string."""
+    if not url:
+        return url
+    url = url.strip()
+    try:
+        if "://" not in url:
+            url = "//" + url
+        parsed = urlparse(url)
+        host = parsed.hostname
+        if host:
+            return host.lower()
+        return url.split("/")[0].split(":")[0].lower()
+    except Exception:
+        return url

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ from awlog_server.utils import (
     login_required,
     is_admin,
     get_app_from_window,
+    domain_from_url,
 )
 
 app = create_app()
@@ -104,7 +105,7 @@ def receive_log():
             username=username,
             window_title=data.get("window_title"),
             process_name=data.get("process_name"),
-            url=data.get("url"),
+            url=domain_from_url(data.get("url")),
             start_time=data.get("start_time"),
             end_time=data.get("end_time"),
             duration=data.get("duration"),
@@ -169,7 +170,7 @@ def report_status():
         status=status,
         window_title=data.get("window_title"),
         process_name=data.get("process_name"),
-        url=data.get("url"),
+        url=domain_from_url(data.get("url")),
     )
     db.session.add(rl)
     db.session.commit()


### PR DESCRIPTION
## Summary
- extract hostname from URLs via `domain_from_url`
- save only domain in API endpoints
- send domain from both agent implementations

## Testing
- `python -m py_compile server.py awlog_server/utils.py agent/service_agent.py agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_688b37485da4832b962cd3bdbad5a9d8