### PR TITLE
Remove startup cleanup step

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -857,9 +857,6 @@ class MainWindow(QWidget):
         self.status_label.setText("Durum: Bekleniyor...")
 
     def _start_workflow(self):
-        self.status_label.setText("Durum: Temizlik yapılıyor...")
-        kill_all_forticlient_processes()
-        time.sleep(2)
 
         if not vpn_connected():
             self.set_connection_status(False, False)


### PR DESCRIPTION
## Summary
- don't kill FortiClient when starting the agent

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688b74069a7c832bbcd8930b50f8ed0a