### PR TITLE
Add URL column in usage report

### DIFF
--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -46,14 +46,16 @@
       <tr>
         <th>Pencere</th>
         <th>Process</th>
+        <th>URL</th>
         <th>Süre</th>
       </tr>
     </thead>
     <tbody>
-      {% for title, proc, dur in usage_rows %}
+      {% for title, proc, url, dur in usage_rows %}
       <tr>
         <td>{{ title }}</td>
         <td>{{ proc }}</td>
+        <td>{{ url }}</td>
         <td>{{ format_duration(dur) }}</td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- group window usage by URL
- show the URL in usage report table

## Testing
- `python -m py_compile server.py awlog_server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688c668d5088832b914768c3cc49b4c8