### PR TITLE
Add pie charts for usage reports

### DIFF
--- a/server.py
+++ b/server.py
@@ -1086,6 +1086,16 @@ def usage_report():
 
     q = request.args.get("q", "").strip().lower()
     usage_rows = get_window_usage_data(selected_user, start.isoformat(), end.isoformat())
+
+    # Aggregate totals for pie charts
+    process_totals: dict[str, int] = {}
+    url_totals: dict[str, int] = {}
+    for _title, proc, url, dur in usage_rows:
+        key = proc or "other"
+        process_totals[key] = process_totals.get(key, 0) + int(dur or 0)
+        domain = domain_from_url(url)
+        if domain:
+            url_totals[domain] = url_totals.get(domain, 0) + int(dur or 0)
     if q:
         usage_rows = [
             (t, p, u, d)
@@ -1104,6 +1114,8 @@ def usage_report():
         usage_rows=usage_rows,
         format_duration=format_duration,
         q=q,
+        process_totals=process_totals,
+        url_totals=url_totals,
     )
 
 

--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -41,6 +41,14 @@
       <button class="btn btn-primary" type="submit">Göster</button>
     </div>
   </form>
+  <div class="row mb-4">
+    <div class="col-md-6 mb-3 mb-md-0">
+      <canvas id="processPie"></canvas>
+    </div>
+    <div class="col-md-6">
+      <canvas id="urlPie"></canvas>
+    </div>
+  </div>
   <table class="table table-bordered table-striped shadow">
     <thead class="table-dark">
       <tr>
@@ -62,5 +70,56 @@
     </tbody>
   </table>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script>
+  const processData = {{ process_totals | tojson }};
+  const urlData = {{ url_totals | tojson }};
+
+  function formatDuration(sec) {
+    sec = Math.round(sec || 0);
+    const h = Math.floor(sec / 3600);
+    const m = Math.floor((sec % 3600) / 60);
+    return h + ':' + String(m).padStart(2, '0');
+  }
+
+  const processLabels = Object.keys(processData);
+  const processValues = Object.values(processData);
+  const urlLabels = Object.keys(urlData);
+  const urlValues = Object.values(urlData);
+
+  new Chart(document.getElementById('processPie'), {
+    type: 'pie',
+    data: {
+      labels: processLabels,
+      datasets: [{ data: processValues }]
+    },
+    options: {
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
+          }
+        }
+      }
+    }
+  });
+
+  new Chart(document.getElementById('urlPie'), {
+    type: 'pie',
+    data: {
+      labels: urlLabels,
+      datasets: [{ data: urlValues }]
+    },
+    options: {
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
+          }
+        }
+      }
+    }
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- aggregate process and URL totals in `/usage_report`
- show two pie charts for process and URL data

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_688c69201e74832bbcf7c12cabc4eee7