### PR TITLE
Improve pie charts in usage report

### DIFF
--- a/server.py
+++ b/server.py
@@ -1096,6 +1096,14 @@ def usage_report():
         domain = domain_from_url(url)
         if domain:
             url_totals[domain] = url_totals.get(domain, 0) + int(dur or 0)
+
+    # Display only top 10 entries in pie charts
+    process_totals = dict(
+        sorted(process_totals.items(), key=lambda x: x[1], reverse=True)[:10]
+    )
+    url_totals = dict(
+        sorted(url_totals.items(), key=lambda x: x[1], reverse=True)[:10]
+    )
     if q:
         usage_rows = [
             (t, p, u, d)

--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -87,7 +87,24 @@
   const urlLabels = Object.keys(urlData);
   const urlValues = Object.values(urlData);
 
-  new Chart(document.getElementById('processPie'), {
+  function enableLegendTooltip(chart) {
+    const legend = chart.options.plugins.legend || {};
+    legend.onHover = (e, item) => {
+      chart.tooltip.setActiveElements(
+        [{ datasetIndex: item.datasetIndex ?? 0, index: item.index }],
+        { x: e.clientX, y: e.clientY }
+      );
+      chart.update();
+    };
+    legend.onLeave = () => {
+      chart.tooltip.setActiveElements([], { x: 0, y: 0 });
+      chart.update();
+    };
+    chart.options.plugins.legend = legend;
+    chart.update();
+  }
+
+  const processChart = new Chart(document.getElementById('processPie'), {
     type: 'pie',
     data: {
       labels: processLabels,
@@ -103,8 +120,9 @@
       }
     }
   });
+  enableLegendTooltip(processChart);
 
-  new Chart(document.getElementById('urlPie'), {
+  const urlChart = new Chart(document.getElementById('urlPie'), {
     type: 'pie',
     data: {
       labels: urlLabels,
@@ -120,6 +138,7 @@
       }
     }
   });
+  enableLegendTooltip(urlChart);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show only the top 10 processes and domains in the usage report pie charts
- display pie chart tooltips when hovering over legend items

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_688c7deacf38832bad15bd7a432c7020