### PR TITLE
Add offline pie charts

### DIFF
--- a/static/simple_pie.js
+++ b/static/simple_pie.js
@@ -1,0 +1,56 @@
+class SimplePie {
+  constructor(canvas, labels, values, opts={}) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.labels = labels;
+    this.values = values;
+    this.colors = opts.colors || [
+      '#3366cc', '#dc3912', '#ff9900', '#109618', '#990099',
+      '#0099c6', '#dd4477', '#66aa00', '#b82e2e', '#316395'
+    ];
+    this.legend = opts.legend;
+    this.format = opts.format || (v => String(v));
+    this.draw();
+  }
+  draw() {
+    const total = this.values.reduce((a,b)=>a+b,0) || 1;
+    let start = -Math.PI/2;
+    const {width, height} = this.canvas;
+    const cx = width/2, cy = height/2;
+    const r = Math.min(cx, cy) - 4;
+    for(let i=0;i<this.values.length;i++){
+      const val = this.values[i];
+      const slice = val/total*2*Math.PI;
+      this.ctx.beginPath();
+      this.ctx.moveTo(cx,cy);
+      this.ctx.arc(cx,cy,r,start,start+slice);
+      this.ctx.closePath();
+      this.ctx.fillStyle = this.colors[i%this.colors.length];
+      this.ctx.fill();
+      start += slice;
+    }
+    if(this.legend) this.drawLegend();
+  }
+  drawLegend() {
+    const total = this.values.reduce((a,b)=>a+b,0) || 1;
+    const ul = document.createElement('ul');
+    ul.style.listStyle='none';
+    ul.style.padding='0';
+    for(let i=0;i<this.labels.length;i++){
+      const li=document.createElement('li');
+      const box=document.createElement('span');
+      box.style.display='inline-block';
+      box.style.width='12px';
+      box.style.height='12px';
+      box.style.marginRight='6px';
+      box.style.background=this.colors[i%this.colors.length];
+      li.appendChild(box);
+      const valText=this.format(this.values[i]);
+      li.appendChild(document.createTextNode(this.labels[i]+': '+valText));
+      ul.appendChild(li);
+    }
+    this.legend.innerHTML='';
+    this.legend.appendChild(ul);
+  }
+}
+window.SimplePie = SimplePie;

--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -42,11 +42,13 @@
     </div>
   </form>
   <div class="row mb-4">
-    <div class="col-md-6 mb-3 mb-md-0">
-      <canvas id="processPie"></canvas>
+    <div class="col-md-6 mb-3 mb-md-0 text-center">
+      <canvas id="processPie" width="300" height="300"></canvas>
+      <div id="processLegend" class="mt-2"></div>
     </div>
-    <div class="col-md-6">
-      <canvas id="urlPie"></canvas>
+    <div class="col-md-6 text-center">
+      <canvas id="urlPie" width="300" height="300"></canvas>
+      <div id="urlLegend" class="mt-2"></div>
     </div>
   </div>
   <table class="table table-bordered table-striped shadow">
@@ -71,6 +73,7 @@
   </table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script src="{{ url_for('static', filename='simple_pie.js') }}"></script>
 <script>
   const processData = {{ process_totals | tojson }};
   const urlData = {{ url_totals | tojson }};
@@ -104,41 +107,56 @@
     chart.update();
   }
 
-  const processChart = new Chart(document.getElementById('processPie'), {
-    type: 'pie',
-    data: {
-      labels: processLabels,
-      datasets: [{ data: processValues }]
-    },
-    options: {
-      plugins: {
-        tooltip: {
-          callbacks: {
-            label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
+  if (window.Chart) {
+    const processChart = new Chart(document.getElementById('processPie'), {
+      type: 'pie',
+      data: {
+        labels: processLabels,
+        datasets: [{ data: processValues }]
+      },
+      options: {
+        plugins: {
+          tooltip: {
+            callbacks: {
+              label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
+            }
           }
         }
       }
-    }
-  });
-  enableLegendTooltip(processChart);
+    });
+    enableLegendTooltip(processChart);
 
-  const urlChart = new Chart(document.getElementById('urlPie'), {
-    type: 'pie',
-    data: {
-      labels: urlLabels,
-      datasets: [{ data: urlValues }]
-    },
-    options: {
-      plugins: {
-        tooltip: {
-          callbacks: {
-            label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
+    const urlChart = new Chart(document.getElementById('urlPie'), {
+      type: 'pie',
+      data: {
+        labels: urlLabels,
+        datasets: [{ data: urlValues }]
+      },
+      options: {
+        plugins: {
+          tooltip: {
+            callbacks: {
+              label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
+            }
           }
         }
       }
-    }
-  });
-  enableLegendTooltip(urlChart);
+    });
+    enableLegendTooltip(urlChart);
+  } else {
+    new SimplePie(
+      document.getElementById('processPie'),
+      processLabels,
+      processValues,
+      { legend: document.getElementById('processLegend'), format: formatDuration }
+    );
+    new SimplePie(
+      document.getElementById('urlPie'),
+      urlLabels,
+      urlValues,
+      { legend: document.getElementById('urlLegend'), format: formatDuration }
+    );
+  }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use a simple canvas-based fallback pie chart when Chart.js fails
- draw legends for the fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c816677dc832bad36533b8a07a754