### PR TITLE
Add duration info to pie chart legends

### DIFF
--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -99,6 +99,18 @@
           callbacks: {
             label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
           }
+        },
+        legend: {
+          labels: {
+            generateLabels: chart => {
+              const items = Chart.defaults.plugins.legend.labels.generateLabels(chart);
+              const values = chart.data.datasets[0].data;
+              items.forEach((it, idx) => {
+                it.text += ' (' + formatDuration(values[idx]) + ')';
+              });
+              return items;
+            }
+          }
         }
       }
     }
@@ -115,6 +127,18 @@
         tooltip: {
           callbacks: {
             label: ctx => ctx.label + ': ' + formatDuration(ctx.parsed)
+          }
+        },
+        legend: {
+          labels: {
+            generateLabels: chart => {
+              const items = Chart.defaults.plugins.legend.labels.generateLabels(chart);
+              const values = chart.data.datasets[0].data;
+              items.forEach((it, idx) => {
+                it.text += ' (' + formatDuration(values[idx]) + ')';
+              });
+              return items;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- add legend callbacks to show each slice's duration in `usage_report.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c88e83a10832b9d6b80dc74deded6