### PR TITLE
Fix pie chart legend labels

### DIFF
--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -104,9 +104,12 @@
           labels: {
             generateLabels: chart => {
               const items = Chart.defaults.plugins.legend.labels.generateLabels(chart);
+              const labels = chart.data.labels || [];
               const values = chart.data.datasets[0].data;
               items.forEach((it, idx) => {
-                it.text += ' (' + formatDuration(values[idx]) + ')';
+                const base = labels[idx] || it.text || it.label || '';
+                const val = values[idx] || 0;
+                it.text = base + ' (' + formatDuration(val) + ')';
               });
               return items;
             }
@@ -133,9 +136,12 @@
           labels: {
             generateLabels: chart => {
               const items = Chart.defaults.plugins.legend.labels.generateLabels(chart);
+              const labels = chart.data.labels || [];
               const values = chart.data.datasets[0].data;
               items.forEach((it, idx) => {
-                it.text += ' (' + formatDuration(values[idx]) + ')';
+                const base = labels[idx] || it.text || it.label || '';
+                const val = values[idx] || 0;
+                it.text = base + ' (' + formatDuration(val) + ')';
               });
               return items;
             }


### PR DESCRIPTION
## Summary
- fix `undefined` pie chart labels in usage_report
- better fallback to `chart.data.labels` when customizing legend labels

## Testing
- `python -m py_compile server.py awlog_server/*.py agent/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688c8abbdec0832b905f819b4ae81e2d