### PR TITLE
Add offline durations to weekly report

### DIFF
--- a/templates/weekly_report.html
+++ b/templates/weekly_report.html
@@ -38,6 +38,7 @@
         <th>Başlama</th>
         <th>Bitiş</th>
         <th>Toplam Online</th>
+        <th>Offline</th>
         <th>Aktif Zaman</th>
         <th>AFK Zaman</th>
       </tr>
@@ -49,6 +50,7 @@
         <td>{{ r.start | local_time('%H:%M') if r.start }}</td>
         <td>{{ r.end | local_time('%H:%M') if r.end }}</td>
         <td>{{ format_duration(r.online) }}</td>
+        <td>{{ format_duration(r.offline) }}</td>
         <td>{{ format_duration(r.active) }}</td>
         <td>{{ format_duration(r.afk) }}</td>
       </tr>


### PR DESCRIPTION
## Summary
- calculate offline durations in `get_weekly_report`
- include offline column in weekly report template and helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c9743780c832b82d6d27441c0d9e2