### PR TITLE
Add top 20 limit to pie charts

### DIFF
--- a/server.py
+++ b/server.py
@@ -1120,6 +1120,14 @@ def usage_report():
         domain = domain_from_url(url)
         if domain:
             url_totals[domain] = url_totals.get(domain, 0) + int(dur or 0)
+
+    # Keep only top 20 entries for the pie charts
+    process_totals = dict(
+        sorted(process_totals.items(), key=lambda x: x[1], reverse=True)[:20]
+    )
+    url_totals = dict(
+        sorted(url_totals.items(), key=lambda x: x[1], reverse=True)[:20]
+    )
     if q:
         usage_rows = [
             (t, p, u, d)


### PR DESCRIPTION
## Summary
- limit pie chart data for process and URL usage to top 20 entries

## Testing
- `python -m py_compile server.py awlog_server/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688cb1b229e4832b9e9ad8c5d234d9bd