### PR TITLE
Fix table layout overflow

### DIFF
--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -6,7 +6,7 @@
     <style>
         body { background: #f6f6fa; }
         .container { max-width: 900px; margin-top: 40px; }
-        table { font-size: 15px; }
+        table { font-size: 15px; word-break: break-word; }
         h2 { margin-bottom: 20px; }
     </style>
 </head>
@@ -49,6 +49,7 @@
       <canvas id="urlPie"></canvas>
     </div>
   </div>
+  <div class="table-responsive">
   <table class="table table-bordered table-striped shadow">
     <thead class="table-dark">
       <tr>
@@ -69,6 +70,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- prevent long data from overflowing by allowing word breaks
- wrap the usage report table in a responsive container for horizontal scrolling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cb3e8cdc4832bbb01ccc51aec5cee