### PR TITLE
Fix narrow columns in usage report

### DIFF
--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -7,6 +7,9 @@
         body { background: #f6f6fa; }
         .container { max-width: 900px; margin-top: 40px; }
         table { font-size: 15px; word-break: break-word; }
+        th:nth-child(2), td:nth-child(2) { min-width: 150px; }
+        th:nth-child(3), td:nth-child(3) { min-width: 200px; }
+        th:nth-child(4), td:nth-child(4) { min-width: 80px; white-space: nowrap; }
         h2 { margin-bottom: 20px; }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- widen columns in `usage_report.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ❌ `pip install flake8` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688cb77a3b70832bbffa819ab8134556