### PR TITLE
Enlarge usage report charts

### DIFF
--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -5,12 +5,12 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body { background: #f6f6fa; }
-        .container { max-width: 900px; margin-top: 40px; }
+        .container { max-width: 1100px; margin-top: 40px; }
         table { font-size: 15px; word-break: break-word; table-layout: fixed; }
         th:nth-child(2), td:nth-child(2) { min-width: 150px; }
         th:nth-child(3), td:nth-child(3) { min-width: 200px; }
         th:nth-child(4), td:nth-child(4) { min-width: 80px; white-space: nowrap; }
-        .chart-container { min-height: 360px; }
+        .chart-container { min-height: 450px; }
         h2 { margin-bottom: 20px; }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- make the usage report container wider so the list isn't cramped
- increase pie chart height so labels have space

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688cc0491720832ba2389dabc3d7d9b8