### PR TITLE
Ensure Process and URL columns don't wrap

### DIFF
--- a/templates/usage_report.html
+++ b/templates/usage_report.html
@@ -7,7 +7,12 @@
         body { background: #f6f6fa; }
         .container { max-width: 1100px; margin-top: 40px; }
         table { font-size: 15px; word-break: break-word; }
-        th:nth-child(4), td:nth-child(4) { width: 1%; white-space: nowrap; }
+        th:nth-child(2), td:nth-child(2),
+        th:nth-child(3), td:nth-child(3),
+        th:nth-child(4), td:nth-child(4) {
+            width: 1%;
+            white-space: nowrap;
+        }
         .chart-container { min-height: 450px; }
         h2 { margin-bottom: 20px; }
     </style>


### PR DESCRIPTION
## Summary
- stop table columns Process, URL, and Duration from wrapping to a second line on the usage statistics page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688cc344ead8832bb2f63512e65e0030